### PR TITLE
fix french typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <div class="container">
         <div class="settings">
-            <h1>Verbs Français</h1>
+            <h1>Verbes Français</h1>
             <div class="holders">
                 <div class="mode">
                     <select name="mode" id="mode">
@@ -31,7 +31,7 @@
                     <select name="tense" id="tense">
                         <option value="all_t">All</option>
                         <option value="P">Present</option>
-                        <option value="pc">Passe Composé</option>
+                        <option value="pc">Passé Composé</option>
                         <option value="I">Imparfait</option>
                         <option value="PQP">Plus-Que-Parfait</option>
                         <option value="F">Future</option>


### PR DESCRIPTION
"Verbs Français" is incorrect, it should be "Verbes". Also "passé" has an "é" at the end. Also the general inconsistency between English and French (especially with the tense names) is not very elegant